### PR TITLE
Export `unsafe_empty_trace`

### DIFF
--- a/eko-gc/src/trace.rs
+++ b/eko-gc/src/trace.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, HashMap};
 
 pub unsafe trait Trace {}
 
+#[macro_export]
 macro_rules! unsafe_empty_trace {
     ($type:ident) => {
         unsafe impl Trace for $type {}


### PR DESCRIPTION
Adds the `#[macro_export]` attribute to `unsafe_empty_trace` so that it may be used in dependent crates.